### PR TITLE
fix option 2: Clone the texture before giving it to the Tile

### DIFF
--- a/src/map/LTexture.cpp
+++ b/src/map/LTexture.cpp
@@ -20,6 +20,17 @@ LTexture::LTexture(SDL_Renderer* pRenderer):
     this->mRenderer = pRenderer;
 }
 
+LTexture::LTexture(const LTexture& texture) {
+    this->mTexture = texture.mTexture;
+    this->mRenderer = texture.mRenderer;
+    this->mWidth = texture.mWidth;
+    this->mHeight = texture.mHeight;
+    this->posX = texture.posX;
+    this->posY = texture.posY;
+    this->clip = texture.clip;
+    this->mRenderer = texture.mRenderer;
+};
+
 //---------------------------------------------------------//
 
 LTexture::~LTexture() {

--- a/src/map/LTexture.hpp
+++ b/src/map/LTexture.hpp
@@ -27,6 +27,8 @@ class LTexture{
         LTexture(SDL_Renderer* pRenderer);
         ~LTexture();
 
+        LTexture(const LTexture& texture);
+
         void setRender(SDL_Renderer* ren);
 
         bool loadFromFile(std::string path);

--- a/src/map/Tilemap.cpp
+++ b/src/map/Tilemap.cpp
@@ -185,9 +185,9 @@ void Tilemap::setTileMap() {
 
         for(int y = 0; y < tilemapHeight; y++) {
 
-            tileArray[x][y] = new Tile(tilemapTex, -1, 48.f, true, 6, camera);
-            //tileArray[x][y]->setPosition(x * 48, y * 48);
-            //tileArray[x][y]->init(map[x][y], tileSize, arr[map[x][y]].moveable, 6);
+            tileArray[x][y] = new Tile(new LTexture(*tilemapTex), -1, 48.f, true, 6, camera);
+            tileArray[x][y]->setPosition(x * 48, y * 48);
+            tileArray[x][y]->init(map[x][y], tileSize, arr[map[x][y]].moveable, 6);
         }
     }
 
@@ -203,8 +203,8 @@ void Tilemap::renderTileMap() {
 
             // Cant set the tiles everytime we render cause that causes memory nom nom....
             //tileArray[i][j] = new Tile(tilemapTex, map[i][j], tileSize, arr[map[i][j]].moveable, 6, camera);
-            tileArray[i][j]->init(map[i][j], tileSize, arr[map[i][j]].moveable, 6);
-            tileArray[i][j]->setPosition(i * 48, j * 48);
+            //tileArray[i][j]->init(map[i][j], tileSize, arr[map[i][j]].moveable, 6);
+            //tileArray[i][j]->setPosition(i * 48, j * 48);
             tileArray[i][j]->render();
 
         }


### PR DESCRIPTION
This is the second fix option where instead of reusing the one texture you could just clone the texture so you don't have the problem of multiple tiles using the same texture